### PR TITLE
Switch to protocolless URIs to support HTTPS

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,7 +1,7 @@
 <html>
   <head>
-    <script src="http://ajax.googleapis.com/ajax/libs/jquery/1.10.2/jquery.min.js"></script>
-    <script src="http://cdnjs.cloudflare.com/ajax/libs/handlebars.js/1.2.1/handlebars.min.js"></script>
+    <script src="//ajax.googleapis.com/ajax/libs/jquery/1.10.2/jquery.min.js"></script>
+    <script src="//cdnjs.cloudflare.com/ajax/libs/handlebars.js/1.2.1/handlebars.min.js"></script>
     <script src="nsa.js"></script>
     <style type="text/css" media="all">@import "ant.css";</style>
     <meta charset="utf-8"></meta>


### PR DESCRIPTION
Some browsers will block HTTP content on HTTPS pages which causes the page not to work. Switching to protocol-free URIs lets the browser select a HTTPS connection if appropriate. (HTTPS Everywhere will default the site to HTTPS).
